### PR TITLE
None should always be compared with "is"

### DIFF
--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ class BaseHandler(webapp2.RequestHandler):
         return self.write(self.render_str(template, **kw))
 
     def render_template(self, view_filename, params=None):
-        if not params:
+        if params is None:
             params = {}
         template = jinja_env.get_template(view_filename)
         return self.response.out.write(template.render(params))


### PR DESCRIPTION
I believe, specially  when teaching beginners, they should be thought the correct way of doing things. Comparisons to singletons like None should always be done with is or is not , never the equality operators.
https://www.python.org/dev/peps/pep-0008/#programming-recommendations
